### PR TITLE
Small fixes and improvements to storing sessions feature

### DIFF
--- a/docstra/chat_db.py
+++ b/docstra/chat_db.py
@@ -5,7 +5,7 @@ import time
 
 class ChatDB:
     def __init__(self):
-        """Initialize the chat database inside .docstra/db/."""
+        # Initialize the chat database inside .docstra/db/.
         self.base_dir = Path(__file__).resolve().parent / ".docstra"
         self.db_dir = self.base_dir / "db"
         self.db_path = self.db_dir / "chat_sessions.db"
@@ -17,7 +17,7 @@ class ChatDB:
         self._initialize_db()
 
     def _initialize_db(self):
-        """Create tables if they don't exist."""
+        # Create tables if they don't exist.
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
@@ -33,7 +33,7 @@ class ChatDB:
         conn.close()
 
     def create_session(self, session_name=None):
-        """Create a new chat session with a custom name and return its ID."""
+        # Create a new chat session with a custom name and return its ID.
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
@@ -47,7 +47,7 @@ class ChatDB:
         return session_id, session_name  # Return session ID and name
 
     def save_message(self, session_id, question, response):
-        """Save a message to the session."""
+        # Save a message to the session.
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
 
@@ -62,7 +62,7 @@ class ChatDB:
         conn.close()
 
     def list_sessions(self):
-        """Retrieve all stored chat sessions."""
+        # Retrieve all stored chat sessions.
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("SELECT id, session_name, created_at FROM chat_sessions ORDER BY created_at DESC")
@@ -71,7 +71,7 @@ class ChatDB:
         return [{"id": s[0], "name": s[1], "created_at": s[2]} for s in sessions]
 
     def get_chat_history(self, session_id):
-        """Retrieve chat history for a given session."""
+        # Retrieve chat history for a given session.
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("SELECT messages FROM chat_sessions WHERE id = ?", (session_id,))
@@ -82,7 +82,7 @@ class ChatDB:
         return None
 
     def get_session_id_by_name(self, session_name):
-        """Retrieve a session ID by its name."""
+        # Retrieve a session ID by its name.
         conn = sqlite3.connect(self.db_path)
         cursor = conn.cursor()
         cursor.execute("SELECT id FROM chat_sessions WHERE session_name = ?", (session_name,))

--- a/docstra/cli.py
+++ b/docstra/cli.py
@@ -45,7 +45,7 @@ header_art = """
 @click.option('--verbose', '-v', is_flag=True, help="Enable all logging.")
 @click.option("--quiet", "-q", is_flag=True, help="Disable all logging.")
 def cli(ctx, verbose, quiet):
-    """Docstra CLI tool for managing repositories and querying codebases."""
+    # Docstra CLI tool for managing repositories and querying codebases.
 
     if verbose:
         logger.setLevel(logging.DEBUG)
@@ -67,7 +67,7 @@ def cli(ctx, verbose, quiet):
 @click.option("--chat-model", "-cm", default="gpt-4o-mini", help="OpenAI model to use for chat.")
 @click.option("--max-tokens", "-t", default=60000, help="Maximum tokens per minute for OpenAI API throttling.")
 def init(repo, api_key, embeddings_model, chat_model, max_tokens):
-    """Initialize repository-specific configuration for Docstra."""
+    # Initialize repository-specific configuration for Docstra.
     repo = Path(repo).resolve()
     docstra_dir = repo / ".docstra"
     env_path = docstra_dir / ".env"
@@ -116,7 +116,7 @@ def init(repo, api_key, embeddings_model, chat_model, max_tokens):
 @cli.command()
 @click.option("--repo", "-rp", default=".", help="Path to the repository to initialize Docstra in.")
 def ingest(repo):
-    """Ingest a repository to extract metadata and store embeddings."""
+    # Ingest a repository to extract metadata and store embeddings
 
     repo = Path(repo).resolve()
     docstra = Docstra(repo)
@@ -171,7 +171,7 @@ def query(question, repo, with_sources, raw_output):
 
 @cli.command()
 def list_sessions():
-    """List all past chat sessions."""
+    # List all previous chat sessions
     sessions = chat_db.get_all_sessions()
     if not sessions:
         click.secho("No chat sessions found.", fg="yellow")
@@ -183,7 +183,7 @@ def list_sessions():
 @cli.command()
 @click.argument("session_id", type=int)
 def show_session(session_id):
-    """Retrieve and display chat history."""
+    # Retrieve and show chat history
     history = chat_db.get_session_history(session_id)
     if not history:
         click.secho(f"No history found for session {session_id}.", fg="red")
@@ -199,7 +199,7 @@ def show_session(session_id):
 @click.option("--repo", "-rp", default=".", help="Path to the repository to initialize Docstra in.")
 @click.option('--with-sources', is_flag=True, default=False, help="Include sources in the response.")
 def chat(repo, with_sources):
-    """Interactive loop for querying with session management."""
+    # Interactive chat loop with stored chat session
 
     repo = Path(repo).resolve()
     docstra = Docstra(repo)
@@ -241,18 +241,24 @@ def chat(repo, with_sources):
         if question.lower() == 'exit':
             break
 
-        result = docstra.query_repository(question)
+        # Get past session messages
+        session_history = chat_db.get_chat_history(session_id)
+
+        # Run query with history
+        result = docstra.query_repository(question, session_history=session_history)
+
         if "answer" in result:
             click.secho(result["answer"])
 
-            # Save message to session
+            # Save the new message to session history
             chat_db.save_message(session_id, question, result["answer"])
+
 
 @cli.command()
 @click.option("--port", "-p", default=8000, help="Port to run the FastAPI server on.")
 @click.option("--host", "-h", default="127.0.0.1", help="Host to run the FastAPI server on.")
 def server(port, host):
-    """Start a FastAPI server for querying repositories."""
+    # Start a FastAPI server for querying repositories.
     from docstra.server import run_server
     run_server(port=port, host=host)
 

--- a/docstra/main.py
+++ b/docstra/main.py
@@ -28,6 +28,7 @@ class Docstra:
     ):
         # Load configurations
         self.repo_path = repo_path
+        self.repo = self.repo_path
         self.core_config = load_core_config()
         self.project_config = load_project_config(repo_path)
 
@@ -67,8 +68,22 @@ class Docstra:
         )
         add_documents_to_vectorstore(self.vectorstore, documents)
 
-    def query_repository(self, query):
-        return run_query(self.retriever, query)
+    # Query the repository for answers, including session history
+    def query_repository(self, question, session_history=None):
+
+        retriever = get_retriever(self.vectorstore)
+
+        # Include previous chat messages in the query (for continuity)
+        history_context = ""
+        if session_history:
+            for entry in session_history:
+                history_context += f"User: {entry['question']}\nDocstra: {entry['response']}\n"
+
+        if history_context:
+            question = f"Previous conversation:\n{history_context}\nCurrent question: {question}"
+
+        result = run_query(retriever, question)
+        return result
 
     def get_retriever(self):
         return self.retriever

--- a/docstra/server.py
+++ b/docstra/server.py
@@ -27,7 +27,7 @@ class QueryRequest(BaseModel):
 
 @app.post("/chat/save")
 async def save_chat(request: QueryRequest):
-    """Save a chat session to the database."""
+    # Save a chat session to the database
     try:
         session_name = f"Session - {request.repo_path}"  # Generate session name
         messages = [{"question": request.query, "answer": "Mock Answer"}]  # Replace with real chat response
@@ -39,7 +39,7 @@ async def save_chat(request: QueryRequest):
 
 @app.get("/chat/sessions")
 async def list_chat_sessions():
-    """List all stored chat sessions."""
+    # list all stored chat sessions
     try:
         sessions = get_chat_sessions()
         return {"sessions": sessions}
@@ -48,7 +48,7 @@ async def list_chat_sessions():
 
 @app.get("/chat/history/{session_id}")
 async def get_chat_history_api(session_id: int):
-    """Retrieve chat history for a specific session."""
+    # Retrieve chat history from a specific session
     try:
         history = get_chat_history(session_id)
         if history is None:


### PR DESCRIPTION
The storing sessions feature now works as expected. You can now also "continue" a conversation with docstra without having to specify what exactly you are referring to. 

I added some new API endpoints for for chat sessions management. 

Made some changes to the CLI (specifically the chat function)

Modified query_repository() to include session history when processing queries.

Makes sure previous questions and answers are available for context in ongoing conversations.

Properly tracks sessions using session IDs instead of overwriting data.

Improved database path handling to avoid conflicts.